### PR TITLE
Fix leading zeros in parser.etw.core.Guid.__str__

### DIFF
--- a/etl/parsers/etw/core.py
+++ b/etl/parsers/etw/core.py
@@ -34,7 +34,7 @@ class Guid:
         return not (self == other)
 
     def __str__(self):
-        return "%x-%x-%x-%s-%s" % (self.data1, self.data2, self.data3, "".join(["%x"%x for x in self.data4[0:2]]), "".join(["%x"%x for x in self.data4[2:]]))
+        return "%x-%x-%x-%s-%s" % (self.data1, self.data2, self.data3, "".join(["%02x"%x for x in self.data4[0:2]]), "".join(["%02x"%x for x in self.data4[2:]]))
 
 
 def guid(guid_str: str) -> Guid:


### PR DESCRIPTION
In the last section of the __str__ method for the Guid class, string padding to the correct hex length is not performed.

If you are comparing a guid which requires zero padding, e.g. *-d312ba227f03, this method will NOT include the 0, causing it to be *-d312ba227f3 (missing zero at the end). If you want to compare string-representations of GUIDs, this code segment will cause you problems.

The fix is simple, in the string-ify operation, simply force the hex character to be printed as exactly two characters, so that zero is always included