### PR TITLE
Add support for Guid field in log_construct_pattern

### DIFF
--- a/bin/etl2xml
+++ b/bin/etl2xml
@@ -120,7 +120,7 @@ def log_construct_pattern(xml: Element, pattern: Struct, source: Container):
             elif source[field.name].type == "CString":
                 add_attribute(xml, field.name, bytearray(source[field.name].string[:-1]).decode("ascii"))
             else:
-                raise InvalidType()
+                raise InvalidType(source[field.name].type)
         elif isinstance(source[field.name], ListContainer):
             add_attribute(xml, field.name, bytearray(source[field.name]).hex())
         elif isinstance(source[field.name],  bytes):

--- a/bin/etl2xml
+++ b/bin/etl2xml
@@ -119,6 +119,8 @@ def log_construct_pattern(xml: Element, pattern: Struct, source: Container):
                 add_attribute(xml, field.name, bytearray(source[field.name].string[:-2]).decode("utf-16le"))
             elif source[field.name].type == "CString":
                 add_attribute(xml, field.name, bytearray(source[field.name].string[:-1]).decode("ascii"))
+            elif source[field.name].type == "Guid":
+                add_attribute(xml, field.name, str(Guid(source[field.name].inner.data1, source[field.name].inner.data2, source[field.name].inner.data3, source[field.name].inner.data4)))
             else:
                 raise InvalidType(source[field.name].type)
         elif isinstance(source[field.name], ListContainer):


### PR DESCRIPTION
Fix two issues:
* TypeError: InvalidType.__init__() missing 1 required positional argument: 'type'
* etl.error.InvalidType: The type Guid is invalid

These issues were raised when parsing an ETL file created by logman for the provider Microsoft-Windows-DotNETRuntimeRundown (A669021C-C450-4609-A035-5AF59AF4DF18)

This PR needs https://github.com/airbus-cert/etl-parser/pull/7 to work.