### PR TITLE
Fix timestamp handling in ETL traces

### DIFF
--- a/bin/etl2pcap
+++ b/bin/etl2pcap
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import struct
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 
 from etl.error import EtwVersionNotFound, EventIdNotFound, GuidNotFound
 from etl.etl import IEtlFileObserver, build_from_stream
@@ -29,15 +29,15 @@ class EtlFileLogger(IEtlFileObserver):
     def on_trace_record(self, event: Trace):
         """ignore this kind of message"""
 
-    def on_event_record(self, event: Event):
+    def on_event_record(self, event: Event, boot_time: int):
         try:
             etw = event.parse_etw()
             # we search for instance of Microsoft_Windows_NDIS_PacketCapture event id 1001 with version 0
             if not isinstance(etw, Microsoft_Windows_NDIS_PacketCapture_1001_0):
                 return
 
-            ft = datetime.utcfromtimestamp(event.source.event_header.timestamp / 10000000)
-            t = (ft-datetime(1970, 1, 1)).total_seconds()
+            ft = datetime(1601, 1, 1, tzinfo=timezone.utc) + timedelta(microseconds=(boot_time + event.source.event_header.timestamp)/10)
+            t = (ft-datetime(1970, 1, 1, tzinfo=timezone.utc)).total_seconds()
 
             self.file_stream.write(struct.pack("<IIII", int(t), ft.microsecond, etw.source.FragmentSize, etw.source.FragmentSize))
             self.file_stream.write(etw.source.Fragment)

--- a/bin/etl2pcap
+++ b/bin/etl2pcap
@@ -23,7 +23,7 @@ class EtlFileLogger(IEtlFileObserver):
     def on_system_trace(self, obj: SystemTraceRecord):
         """ignore this kind of message"""
 
-    def on_perfinfo_trace(self, obj: PerfInfo):
+    def on_perfinfo_trace(self, obj: PerfInfo, boot_time: int):
         """ignore this kind of message"""
 
     def on_trace_record(self, event: Trace):
@@ -45,7 +45,7 @@ class EtlFileLogger(IEtlFileObserver):
         except (EtwVersionNotFound, EventIdNotFound, GuidNotFound):
             """ignore exception"""
 
-    def on_win_trace(self, event: WinTrace):
+    def on_win_trace(self, obj: WinTrace):
         """ignore this kind of message"""
 
 

--- a/bin/etl2xml
+++ b/bin/etl2xml
@@ -180,12 +180,12 @@ class EtlFileLogger(IEtlFileObserver):
         except (GroupNotFound, VersionNotFound, EventTypeNotFound) as e:
             print(e)
 
-    def on_perfinfo_trace(self, obj: PerfInfo, base_ts: int):
+    def on_perfinfo_trace(self, obj: PerfInfo, boot_time: int):
         try:
             mof = obj.get_mof()
             data = ElementTree.SubElement(self.xml_document, "event")
             data.set("type", "perfinfo")
-            data.set("timestamp", str(obj.get_timestamp(base_ts)))
+            data.set("timestamp", str(obj.get_timestamp(boot_time)))
             xml = ElementTree.SubElement(data, "mof")
             xml.set("provider", mof.__class__.__name__)
             log_kernel_type(mof, xml)

--- a/bin/etl2xml
+++ b/bin/etl2xml
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+from datetime import datetime
 
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
@@ -10,10 +11,11 @@ from etl.error import GroupNotFound, VersionNotFound, EventTypeNotFound, EtwVers
     GuidNotFound, TlMetaDataNotFound, InvalidType
 from etl.etl import IEtlFileObserver, build_from_stream
 from etl.parsers.etw.core import Guid
+from etl.parsers.kernel.header import EventTrace_V0_Header
 from etl.wintrace import WinTrace
 from etl.event import Event
 from etl.parsers.kernel import FileIo_V2_Name, ImageLoad, DiskIo_TypeGroup1, \
-    Process_V3_TypeGroup1, Process_V4_TypeGroup1, Process_Defunct_TypeGroup1, ImageLoadProcess
+    Process_V3_TypeGroup1, Process_V4_TypeGroup1, Process_Defunct_TypeGroup1, ImageLoadProcess, EventTraceHeader
 from etl.parsers.kernel.core import Mof
 from etl.parsers.kernel.io import DiskIo_TypeGroup3
 from etl.parsers.tracelogging import TraceLogging
@@ -152,8 +154,16 @@ class EtlFileLogger(IEtlFileObserver):
     """
     This a basic observer that log event
     """
-    def __init__(self):
+    def __init__(self, header: EventTraceHeader | EventTrace_V0_Header):
         self.xml_document = ElementTree.Element("etl")
+        self.xml_document.set("SessionName", header.get_session_name())
+        self.xml_document.set("LogFileName", header.get_log_filename())
+        self.xml_document.set("BootTime", header.get_boot_time().isoformat())
+        self.xml_document.set("TraceStartTime", header.get_start_time().isoformat())
+        self.xml_document.set("TraceEndTime", header.get_end_time().isoformat())
+        self.xml_document.set("TimezoneStandardBias", str(header.source.TimeZoneInformation.standard_bias))
+        self.xml_document.set("TimezoneDaylightBias", str(header.source.TimeZoneInformation.daylight_bias))
+        self.xml_document.set("LostEvents", str(header.source.EventsLost))
 
     def on_system_trace(self, obj: SystemTraceRecord):
         try:
@@ -170,12 +180,12 @@ class EtlFileLogger(IEtlFileObserver):
         except (GroupNotFound, VersionNotFound, EventTypeNotFound) as e:
             print(e)
 
-    def on_perfinfo_trace(self, obj: PerfInfo):
+    def on_perfinfo_trace(self, obj: PerfInfo, base_ts: int):
         try:
             mof = obj.get_mof()
             data = ElementTree.SubElement(self.xml_document, "event")
             data.set("type", "perfinfo")
-            data.set("timestamp", str(obj.get_timestamp()))
+            data.set("timestamp", str(obj.get_timestamp(base_ts)))
             xml = ElementTree.SubElement(data, "mof")
             xml.set("provider", mof.__class__.__name__)
             log_kernel_type(mof, xml)
@@ -186,11 +196,11 @@ class EtlFileLogger(IEtlFileObserver):
     def on_trace_record(self, event: Trace):
         pass
 
-    def on_event_record(self, event: Event):
+    def on_event_record(self, event: Event, boot_time: int):
         try:
             data = ElementTree.Element("event")
             data.set("type", "event")
-            data.set("timestamp", str(event.get_timestamp()))
+            data.set("timestamp", event.get_timestamp(boot_time))
             data.set("PID", str(event.get_process_id()))
             data.set("TID", str(event.get_thread_id()))
             data.append(log_tracelogging(event.parse_tracelogging()))
@@ -200,7 +210,7 @@ class EtlFileLogger(IEtlFileObserver):
                 etw = event.parse_etw()
                 data = ElementTree.SubElement(self.xml_document, "event")
                 data.set("type", "event")
-                data.set("timestamp", str(event.get_timestamp()))
+                data.set("timestamp", event.get_timestamp(boot_time))
                 data.set("PID", str(event.get_process_id()))
                 data.set("TID", str(event.get_thread_id()))
                 xml = ElementTree.SubElement(data, "etw")
@@ -227,9 +237,9 @@ def main(input: str, output: str):
     :param input: input file path
     :param output: output path
     """
-    logger = EtlFileLogger()
     with open(input, "rb") as input_file:
         etl_reader = build_from_stream(input_file.read())
+        logger = EtlFileLogger(etl_reader.header)
         etl_reader.parse(logger)
 
     with open(output, "wb") as output_file:

--- a/etl/etl.py
+++ b/etl/etl.py
@@ -5,7 +5,8 @@ It's directly inspired from :
 :see: https://www.geoffchappell.com/studies/windows/km/ntoskrnl/api/etw/tracelog/wmi_buffer_header.htm
 """
 from abc import ABCMeta, abstractmethod
-from typing import List
+from datetime import datetime
+from typing import List, Any
 
 from construct import Struct, Bytes, CheckError, Aligned, Select, GreedyRange, Container, Computed, RepeatUntil
 
@@ -65,12 +66,13 @@ class IEtlFileObserver(metaclass=ABCMeta):
     Parse sequentially an etl file and commit event when found a particular event
     """
     @abstractmethod
-    def on_event_record(self, event: Event):
+    def on_event_record(self, event: Event, boot_time: int):
         """
         Raise when an event record is parsed
-        Mostly use by ETW and tracelogging
+        Mostly used by ETW and tracelogging
         If you search classic provider you are at the correct place
         :param event: the event record
+        :param boot_time: machine's boot time (as Windows FILETIME) to be used as offset for the events' timestamp.
         """
 
     @abstractmethod
@@ -82,12 +84,13 @@ class IEtlFileObserver(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def on_perfinfo_trace(self, obj: PerfInfo):
+    def on_perfinfo_trace(self, obj: PerfInfo, boot_time: int):
         """
         Raise when a wmi perfinfo trace is parsed
         Mostly use as mof container
         If you want to parse some kernel log you are at the correct place
         You can use system trace too
+        :param boot_time: machine's boot time (as Windows FILETIME) to be used as offset for the events' timestamp.
         """
 
     @abstractmethod
@@ -116,24 +119,25 @@ class EtlFile:
     The parse function will traverse all ETL chunks
     and call appropriate function depends on node type
     """
-    def __init__(self, header: Mof, chunks: List[Container]):
+    def __init__(self, header: EventTraceHeader | EventTrace_V0_Header, chunks: List[Container]):
         """
-        :param header System: This is the first chunk of ETL file, wich include some meta infos about file creation
+        :param header: This is the first chunk of ETL file, which include some meta infos about file creation
         :param chunks: List of all chunk (not all event)
         """
         self.header = header
         self.chunks = chunks
-
+        self.boot_time = header.source.BootTime
+        
     def parse(self, observer: IEtlFileObserver):
         """
         Parse the ETL file
         :param observer IEtlFileObserver: observer pattern
         """
         actions = {
-            "EventRecord": lambda obj: observer.on_event_record(Event(obj)),
+            "EventRecord": lambda obj: observer.on_event_record(Event(obj), boot_time=self.boot_time),
             "TraceRecord": lambda obj: observer.on_trace_record(Trace(obj)),
             "SystemTraceRecord": lambda obj: observer.on_system_trace(System(obj)),
-            "PerfInfoTraceRecord": lambda obj: observer.on_perfinfo_trace(PerfInfo(obj)),
+            "PerfInfoTraceRecord": lambda obj: observer.on_perfinfo_trace(PerfInfo(obj), boot_time=self.boot_time),
             "WinTraceRecord": lambda obj: observer.on_win_trace(WinTrace(obj))
         }
         for chunk in self.chunks:

--- a/etl/event.py
+++ b/etl/event.py
@@ -3,6 +3,7 @@
 Parse an event record
 :see: https://docs.microsoft.com/fr-fr/windows/desktop/api/evntcons/ns-evntcons-_event_record
 """
+from datetime import timedelta, datetime, timezone
 
 from construct import Struct, Int16ul, Enum, Int32ul, Int64ul, FlagsEnum, Int8ul, Bytes, Aligned, RepeatUntil, Computed, \
     AlignedStruct, If
@@ -103,11 +104,15 @@ class Event:
         """
         return self.source.event_header.thread_id
 
-    def get_timestamp(self) -> int:
+    def get_timestamp(self, boot_time: int) -> str:
         """
-        :return: Timestamp associated with this event
+        Return the ISO-formatted timestamp of the Event. The integer value stored in the Event structure is the number
+        of 100-nanosecond intervals since the last boot. This is why the machine's boot time is needed to calculate the
+        Event's actual timestamp.
+        :param: boot_time: the machine's boot time in FILETIME integer format
+        :return: ISO-formatted timestamp associated with this event.
         """
-        return self.source.event_header.timestamp
+        return (datetime(1601, 1, 1, tzinfo=timezone.utc) + timedelta(microseconds=(boot_time + self.source.event_header.timestamp)/10)).isoformat(timespec="microseconds")
 
     def parse_etw(self) -> Etw:
         """

--- a/etl/parsers/kernel/header.py
+++ b/etl/parsers/kernel/header.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from construct import Struct, Int32ul, Int64ul, RepeatUntil, Byte
+from datetime import datetime, timedelta, timezone
 
 from etl.parsers.kernel.core import declare, Mof
 from etl.utils import TimeZoneInformation, WString
@@ -27,6 +28,7 @@ class EventTraceHeader(Mof):
         "CPUSpeed" / Int32ul,
         "LoggerName" / Int64ul,
         "LogFileName" / Int64ul,
+        "Padding" / Int32ul,
         "TimeZoneInformation" / TimeZoneInformation,
         "BootTime" / Int64ul,
         "PerfFreq" / Int64ul,
@@ -49,6 +51,23 @@ class EventTraceHeader(Mof):
         """
         return bytearray(self.source.LogFileNameString.string[:-2]).decode("utf-16le")
 
+    def get_boot_time(self) -> datetime:
+        """
+        :return: Return the time when the machine booted
+        """
+        return datetime(1601, 1, 1, tzinfo=timezone.utc) + timedelta(microseconds=self.source.BootTime / 10)
+
+    def get_start_time(self) -> datetime:
+        """
+        :return: Return the time when the trace started
+        """
+        return datetime(1601, 1, 1, tzinfo=timezone.utc) + timedelta(microseconds=self.source.StartTime / 10)
+
+    def get_end_time(self) -> datetime:
+        """
+        :return: Return the time when the trace ended
+        """
+        return datetime(1601, 1, 1, tzinfo=timezone.utc) + timedelta(microseconds=self.source.EndTime / 10)
 
 @declare(group=EventTraceGroup.EVENT_TRACE_GROUP_HEADER, version=2, event_types=[5, 32])
 class Header_Extension_TypeGroup(Mof):

--- a/etl/perf.py
+++ b/etl/perf.py
@@ -6,6 +6,7 @@ It use by kernel logger to send event but more concise than in system trace form
 But add timestamp of the event
 This an event driven log but without some of meta infos
 """
+from datetime import datetime, timezone, timedelta
 
 from construct import Struct, Enum, Int64ul, Bytes, Int8ul, Container
 
@@ -33,11 +34,18 @@ class PerfInfo:
     def __init__(self, source: Container):
         self.source = source
 
-    def get_timestamp(self) -> int:
+    def get_timestamp(self, boot_time: int) -> str:
         """
-        :return: Timestamp associated with this event
+        Return the ISO-formatted timestamp of the PerfInfo record. The integer value stored in the PerfInfo record
+        structure is the number of 100-nanosecond intervals since the last boot. This is why the machine's boot time is
+        needed to calculate the Event's actual timestamp.
+        :param: boot_time: the machine's boot time in FILETIME integer format
+        :return: ISO-formatted timestamp associated with this event.
         """
-        return self.source.timestamp
+        return (
+                datetime(1601, 1, 1, tzinfo=timezone.utc)
+                + timedelta(microseconds=(boot_time + self.source.event_header.timestamp)/10)
+        ).isoformat(timespec="microseconds")
 
     def get_mof(self) -> Mof:
         """

--- a/etl/utils.py
+++ b/etl/utils.py
@@ -42,9 +42,9 @@ TimeZoneInformation = Struct(
     "standard_name" / Byte[64],
     "standard_date" / SystemTime,
     "standard_bias" / Int32sl,
-    "delight_name" / Byte[64],
-    "delight_date" / SystemTime,
-    "delight_bias" / Int32sl
+    "daylight_name" / Byte[64],
+    "daylight_date" / SystemTime,
+    "daylight_bias" / Int32sl
 )
 
 PerfinfoGroupMask = Struct(


### PR DESCRIPTION
This PR fixes the timestamps handling in various traces:
* Add some metadata in the root <etl> element, such as the machine's boot time, trace's start and end time
* Use the machine's boot time to correctly parse the timestamp from the events
* Fix some deprecation warnings about timezone-naive timestamps in etl2pcap

This should address and fix #11 